### PR TITLE
Attempt to improve logger performance.

### DIFF
--- a/lua/mvp/core/logger/sh_logger.lua
+++ b/lua/mvp/core/logger/sh_logger.lua
@@ -36,7 +36,7 @@ function mvp.logger.Log(level, caller, ...)
             logger:Log(level, caller, unpack(args))
         end)
         
-        if (level == mvp.LOG.ERROR) then
+        if (level == mvp.LOG.ERROR and (mvp.config and mvp.config.Get("debug", false))) then
             pcall(function()
                 local trace = mvp.utils.GetTrace()
 

--- a/lua/mvp/loggers/console.lua
+++ b/lua/mvp/loggers/console.lua
@@ -16,21 +16,36 @@ local LEVEL_TO_COLOR_MAP = {
 local COLOR_WHITE = Color(255, 255, 255)
 local COLOR_YELLOW = Color(255, 255, 0)
 
+local noOp = function() end
+
+local msgC = MsgC
+local mvpLog = mvp.LOG
 function LOGGER:Log(level, caller, ...)
-    local shouldDisplayDebug = mvp.config and mvp.config.Get("debug", false)
-    if (not shouldDisplayDebug and level == mvp.LOG.DEBUG) then
-        return
+    if (level == mvpLog.DEBUG) then
+        if (not mvp.config or not mvp.config.Get("debug", false)) then
+            return 
+        end
     end
 
     local color = LEVEL_TO_COLOR_MAP[level] or COLOR_WHITE
 
-    MsgC(
-        color, "▌ ", mvp.LOG[level], "\t",
-        COLOR_YELLOW, caller and ("[" .. caller .. "] ") or "",
+    if (caller) then
+        msgC(
+            color, "▌ ", mvpLog[level], "\t",
+            COLOR_YELLOW, "[", caller, "] ",
+            COLOR_WHITE, ...,
+            "\n"
+        )
+        return 
+    end
+    
+    msgC(
+        color, "▌ ", mvpLog[level], "\t",
         COLOR_WHITE, ...,
         "\n"
     )
 end
+
 function LOGGER:LogOld(level, caller, ...)
     local shouldDisplayDebug = mvp.config and mvp.config.Get("debug", false)
     if (not shouldDisplayDebug and level == mvp.LOG.DEBUG) then

--- a/lua/mvp/loggers/console.lua
+++ b/lua/mvp/loggers/console.lua
@@ -13,34 +13,23 @@ local LEVEL_TO_COLOR_MAP = {
     [mvp.LOG.DEBUG] = Color(4, 0, 255),
 }
 
+local COLOR_WHITE = Color(255, 255, 255)
+local COLOR_YELLOW = Color(255, 255, 0)
+
 function LOGGER:Log(level, caller, ...)
     local shouldDisplayDebug = mvp.config and mvp.config.Get("debug", false)
     if (not shouldDisplayDebug and level == mvp.LOG.DEBUG) then
         return
     end
 
-    local color = LEVEL_TO_COLOR_MAP[level] or Color(255, 255, 255)
+    local color = LEVEL_TO_COLOR_MAP[level] or COLOR_WHITE
 
-    local msg = {}
-
-    msg[#msg + 1] = color
-    msg[#msg + 1] = "▌ "
-    msg[#msg + 1] = mvp.LOG[level]
-    msg[#msg + 1] = "\t"
-    msg[#msg + 1] = Color(255, 255, 255)
-    
-    if (caller) then
-        msg[#msg + 1] = "["
-        msg[#msg + 1] = Color(255, 255, 0)
-        msg[#msg + 1] = caller
-        msg[#msg + 1] = Color(255, 255, 255)
-        msg[#msg + 1] = "] "
-    end
-
-    table.Add(msg, {...})
-
-    MsgC(unpack(msg))
-    Msg("\n")
+    MsgC(
+        color, "▌ ", mvp.LOG[level], "\t",
+        COLOR_YELLOW, caller and ("[" .. caller .. "] ") or "",
+        COLOR_WHITE, ...,
+        "\n"
+    )
 end
 
 mvp.logger.Register(LOGGER)

--- a/lua/mvp/loggers/console.lua
+++ b/lua/mvp/loggers/console.lua
@@ -16,21 +16,35 @@ local LEVEL_TO_COLOR_MAP = {
 local COLOR_WHITE = Color(255, 255, 255)
 local COLOR_YELLOW = Color(255, 255, 0)
 
+local noOp = function() end
+
+local msgC = MsgC
+local mvpLog = mvp.LOG
 function LOGGER:Log(level, caller, ...)
-    local shouldDisplayDebug = mvp.config and mvp.config.Get("debug", false)
-    if (not shouldDisplayDebug and level == mvp.LOG.DEBUG) then
-        return
+    if (level == mvpLog.DEBUG) then
+        if (not mvp.config or not mvp.config.Get("debug", false)) then
+            return 
+        end
     end
 
     local color = LEVEL_TO_COLOR_MAP[level] or COLOR_WHITE
 
-    MsgC(
-        color, "▌ ", mvp.LOG[level], "\t",
-        COLOR_YELLOW, caller and ("[" .. caller .. "] ") or "",
-        COLOR_WHITE, ...,
-        "\n"
-    )
+    if (caller) then
+        msgC(
+            color, "▌ ", mvpLog[level], "\t",
+            COLOR_YELLOW, "[", caller, "] ",
+            COLOR_WHITE, ...,
+            "\n"
+        )
+    else
+        msgC(
+            color, "▌ ", mvpLog[level], "\t",
+            COLOR_WHITE, ...,
+            "\n"
+        )
+    end
 end
+
 function LOGGER:LogOld(level, caller, ...)
     local shouldDisplayDebug = mvp.config and mvp.config.Get("debug", false)
     if (not shouldDisplayDebug and level == mvp.LOG.DEBUG) then
@@ -77,7 +91,7 @@ local function testOldNoCaller()
 end
 
 concommand.Add("mvp_log_test", function()
-    LuctusCompareOften(10, 0.1, 1000, {
+    LuctusCompareOften(10, 0.1, 5000, {
         {"new implementation, with caller", testNew},
         {"new implementation, without caller", testNewNoCaller},
 

--- a/lua/mvp/loggers/console.lua
+++ b/lua/mvp/loggers/console.lua
@@ -31,5 +31,57 @@ function LOGGER:Log(level, caller, ...)
         "\n"
     )
 end
+function LOGGER:LogOld(level, caller, ...)
+    local shouldDisplayDebug = mvp.config and mvp.config.Get("debug", false)
+    if (not shouldDisplayDebug and level == mvp.LOG.DEBUG) then
+        return
+    end
+
+    local color = LEVEL_TO_COLOR_MAP[level] or Color(255, 255, 255)
+
+    local msg = {}
+
+    msg[#msg + 1] = color
+    msg[#msg + 1] = "▌ "
+    msg[#msg + 1] = mvp.LOG[level]
+    msg[#msg + 1] = "\t"
+    msg[#msg + 1] = Color(255, 255, 255)
+    
+    if (caller) then
+        msg[#msg + 1] = "["
+        msg[#msg + 1] = Color(255, 255, 0)
+        msg[#msg + 1] = caller
+        msg[#msg + 1] = Color(255, 255, 255)
+        msg[#msg + 1] = "] "
+    end
+
+    table.Add(msg, {...})
+
+    MsgC(unpack(msg))
+    Msg("\n")
+end
 
 mvp.logger.Register(LOGGER)
+
+local function testNew()
+    LOGGER:Log(mvp.LOG.INFO, "TestCaller", "This is an info message")
+end
+local function testNewNoCaller()
+    LOGGER:Log(mvp.LOG.INFO, nil, "This is an info message")
+end
+local function testOld()
+    LOGGER:LogOld(mvp.LOG.INFO, "TestCaller", "This is an info message")
+end
+local function testOldNoCaller()
+    LOGGER:LogOld(mvp.LOG.INFO, nil, "This is an info message")
+end
+
+concommand.Add("mvp_log_test", function()
+    LuctusCompareOften(10, 0.1, 1000, {
+        {"new implementation, with caller", testNew},
+        {"new implementation, without caller", testNewNoCaller},
+
+        {"old implementation, with caller", testOld},
+        {"old implementation, without caller", testOldNoCaller}
+    })
+end)

--- a/lua/mvp/thirdparty/sh_luctus_benchmark.lua
+++ b/lua/mvp/thirdparty/sh_luctus_benchmark.lua
@@ -1,0 +1,112 @@
+--Luctus Benchmark
+--Made by OverlordAkise
+
+--This is a very small and simple collection of functions for
+--benchmarking lua functions for "time taken". It is nothing special
+
+--[[ Example code
+
+LuctusCompareOften( 10, 0.2, 10000, {
+    {"darkrpvar", function() local a = Entity(1):getDarkRPVar("job") end},
+    {"gmodnwvar", function() local a = Entity(1):GetNWString("job") end},
+})
+
+--The above code compares GetNWString function to getDarkRPVar
+
+--]]
+
+--source for ranStr: https://gist.github.com/haggen/2fd643ea9a261fea2094
+local chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+function ranStr(length)
+    if not length then length = 8 end
+    if length == 0 then return "" end
+    local pos = math.random(1, #chars)
+    return ranStr(length - 1) .. chars:sub(pos, pos)
+end
+
+function ranInt(maxInt)
+    if not maxInt then maxInt = 999999 end
+    return math.random(1,maxInt)
+end
+
+local intToKeep = 0
+local getsRemaining = 0
+function sameInt(keepFor)
+    if keepFor then
+        getsRemaining = keepFor
+        intToKeep = ranInt()
+        return intToKeep
+    end
+    if getsRemaining > 0 then
+        getsRemaining = getsRemaining -1
+        return intToKeep
+    end
+    error("How did we get here")
+end
+
+function ranFloat()
+    return math.random()
+end
+
+function calcSum(tab)
+    local sum = 0
+    for i=1,#tab do
+        sum = sum + tab[i]
+    end
+    return sum
+end
+
+function LuctusCompareOften(repeats,delay,rounds,tableOfFuncs)
+    local results = {}
+    local p = function()end
+    timer.Create("LuctusBenchmark",delay,repeats,function()
+        local res = LuctusCompare(rounds,tableOfFuncs,p)
+        for i=1,#res do
+            if not results[i] then results[i] = {} end
+            table.insert(results[i],res[i])
+        end
+        if timer.RepsLeft("LuctusBenchmark") == 0 then
+            print("--- Benchmark complete")
+            print("reps",repeats,"rounds",rounds)
+            print(SERVER and "On Server" or "On Client")
+            for i=1,#results do
+                local name = tableOfFuncs[i][1]
+                if name == "" then continue end
+                print(name,calcSum(results[i])/#results[i])
+            end
+        end
+    end)
+end
+
+function LuctusCompare(rounds,tableOfFuncs,p)
+    if not p then p = print end
+    local funcCount = #tableOfFuncs
+    local rv = {}
+    local curFunc = 1
+    --warmup
+    for i=1,funcCount do
+        tableOfFuncs[i][2]()
+    end
+    --run
+    for i=1,rounds*funcCount do
+        local func = tableOfFuncs[curFunc][2]
+        local starttime = SysTime()
+        func()
+        local endtime = SysTime()
+        if not rv[curFunc] then rv[curFunc] = {} end
+        table.insert(rv[curFunc],endtime-starttime)
+        curFunc = (curFunc%funcCount)+1
+    end
+    --result
+    p("--- Benchmark complete")
+    p("rounds",rounds)
+    p(SERVER and "On Server" or "On Client")
+    local result = {}
+    for i=1,#rv do
+        p(tableOfFuncs[i][1],calcSum(rv[i])/#rv[i])
+        table.insert(result,calcSum(rv[i])/#rv[i])
+    end
+    return result
+end
+
+print("[luctus_benchmark] loaded")


### PR DESCRIPTION
Closes #4 

Benchmarks were done using [this](https://github.com/OverlordAkise/gmod-lua-performance/blob/main/luctus_benchmark.lua)

```
--- Benchmark complete
reps    10      rounds  1000
On Server
new implementation, with caller 0.00057225360000003
new implementation, without caller      0.00036605403
old implementation, with caller 0.00091541348000008
old implementation, without caller      0.00058401725000005
```

There are significant increase in performance (by around 50%, if I'm reading that right), but it is just console logger itself. I see some other [places](https://github.com/MULTIVERSE-Project/terminal/blob/main/lua/mvp/core/logger/sh_logger.lua#L27-L47) where it can be improved.

Benchmark code:
```lua
local function testNew()
    LOGGER:Log(mvp.LOG.INFO, "TestCaller", "This is an info message")
end
local function testNewNoCaller()
    LOGGER:Log(mvp.LOG.INFO, nil, "This is an info message")
end
local function testOld()
    LOGGER:LogOld(mvp.LOG.INFO, "TestCaller", "This is an info message")
end
local function testOldNoCaller()
    LOGGER:LogOld(mvp.LOG.INFO, nil, "This is an info message")
end

concommand.Add("mvp_log_test", function()
    LuctusCompareOften(10, 0.1, 1000, {
        {"new implementation, with caller", testNew},
        {"new implementation, without caller", testNewNoCaller},

        {"old implementation, with caller", testOld},
        {"old implementation, without caller", testOldNoCaller}
    })
end)
```
Log and LogOld contains new implementation and old one.